### PR TITLE
Include elm-debug-transformer - or should it be a Parcel plugin?

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In the parent directory of your (soon-to-be) project:
 $ elm-app-gen yourProjectName
 ```
 
-You'll be prompted to provide some information about your project, such as a 
+You'll be prompted to provide some information about your project, such as a
 license, description, and they type of Elm program to generate. When you're done,
 the new app is created in a directory based on the name you provided. It will
 contain a README with instructions on how to start a live server and perform
@@ -35,14 +35,14 @@ other development tasks.
 
 ## QuickStart
 
-If you want to start coding as quickly as possible, you can run 
+If you want to start coding as quickly as possible, you can run
 
 ```
 $ elm-app-gen quickstart yourProjectName
 ```
 
 This will create a an application with default settings and immediately
-start an application server. 
+start an application server.
 
 ## What's included in a new project?
 
@@ -51,6 +51,7 @@ Elm App Generator creates a project for you that includes:
 - [Elm](https://elm-lang.org)
 - [Elm Test](https://package.elm-lang.org/packages/elm-exploration/test/latest)
 - [Parcel](https://parceljs.org)
+- [`elm-debug-transformer`](https://github.com/kraklin/elm-debug-transformer)
 
 The list of initial dependencies is intentionally small to keep your app simple
 until it needs more features and tools.
@@ -67,8 +68,8 @@ particular task, Elm App Generator opts for the simpler choice.
 ### Friendly
 
 Elm App Generator always tries to provide useful context when asking users to make
-decisions. When the user needs to take additional steps, it will describe them when 
-it runs, and include them in the documentation for the generated application. 
+decisions. When the user needs to take additional steps, it will describe them when
+it runs, and include them in the documentation for the generated application.
 Generated apps contain links to documentation for the libraries and tools in use.
 
 ### Explicit

--- a/generators/app/templates/parcel/README.md
+++ b/generators/app/templates/parcel/README.md
@@ -14,7 +14,7 @@
 
 `<%= installer %> start`
 
-Will compile your app and serve it from http://localhost:1234/ 
+Will compile your app and serve it from http://localhost:1234/
 Changes to your source code will trigger a hot-reload in the browser, which
 will also show compiler errors on build failures.
 
@@ -73,3 +73,10 @@ really useful!
 
 Parcel build and bundles the application's assets into individual HTML, CSS, and
 JavaScript files. It also runs the live-server used during development.
+
+### [`elm-debug-transform`](https://github.com/kraklin/elm-debug-transformer)
+
+This is a simple tool for improving the output of `Debug.log` statements.
+It applies some nice formatting for elm data structures. When you do a
+`parcel build` to produce your prod bundle, this won't be wired in.
+Read more in this discourse post: https://discourse.elm-lang.org/t/nicer-debug-log-console-output/3780.

--- a/generators/app/templates/parcel/app.js
+++ b/generators/app/templates/parcel/app.js
@@ -1,6 +1,11 @@
 import { Elm } from "../Main.elm";
 import * as ElmDebugger from "elm-debug-transformer";
-ElmDebugger.register();
+
+if (process.env.NODE_ENV === 'development') {
+  // Only runs in development and will be stripped from production build.
+  // See https://parceljs.org/production.html
+  ElmDebugger.register();
+}
 
 Elm.Main.init({
   node: document.getElementById("app")

--- a/generators/app/templates/parcel/app.js
+++ b/generators/app/templates/parcel/app.js
@@ -1,4 +1,6 @@
 import { Elm } from "../Main.elm";
+import * as ElmDebugger from "elm-debug-transformer";
+ElmDebugger.register();
 
 Elm.Main.init({
   node: document.getElementById("app")

--- a/generators/app/templates/parcel/package.json
+++ b/generators/app/templates/parcel/package.json
@@ -19,6 +19,7 @@
   "dependencies": {},
   "devDependencies": {
     "elm": "^0.19.0-no-deps",
+    "elm-debug-transformer": "0.0.6",
     "elm-hot": "^1.0.1",
     "elm-test": "^0.19.0-rev6",
     "node-elm-compiler": "^5.0.3",


### PR DESCRIPTION
Hey @MattCheely! As a response to your comment https://github.com/dillonkearns/elm-app-gen/commit/40fc3a3f9d600ab20770bac75c1db3952cb2569e#commitcomment-34095109... I'm really liking using `elm-app-gen`, thanks for building it! It works great with Parcel, so nice and simple, and no need to eject.

I had the idea to include `elm-debug-transformer` because it kind of feels like you may as well. But then I realized that some people may not want to have that wired in in their production environments.

So that got me thinking, maybe rather than making a pull request on your repo, it would be better to have it integrated into the Parcel elm builder. Or maybe just a Parcel plugin. I'm not sure I have bandwidth to maintain that, though. Maybe @kraklin would be interested in that??? 😄